### PR TITLE
Fix FTP mysql dump

### DIFF
--- a/lib/wordmove/assets/dump.php.erb
+++ b/lib/wordmove/assets/dump.php.erb
@@ -219,4 +219,6 @@ $db_name = '<%= escape_php db[:name] %>';
 
 $connection = new mysqli($db_host, $db_user, $db_password, $db_name, $db_port);
 $dump = new MySQLDump($connection);
-$dump->save('dump.mysql');
+$db_file = 'dump.mysql';
+$dump->save($db_file);
+readfile($db_file);


### PR DESCRIPTION
In the FTP workflow the `dump.php` script is uploaded and accessed via HTTP to get the dump of the mysql db. The expectation of the FTP deployer is that accessing the `dump.php` script the dump will be returned. In the current implementation the dump is saved to a file but not returned as an HTTP response to the client.

The proposed solution is to echo the dump to the client. 

Another potential solution would be to dump to a file and copy the file via ftp.

Here are the details of the problem: 

When pulling the DB from an environment using FTP `pull_db` is invoked in `ftp.rb`. In turn `download_remote_db` is invoked which finally calls `download(dump_url, local_dump_path)` where `dump_url=/path/to/wp/install/wp_content/dump.php?shared_key=#{one_time_password}`. In `download` we open the `dump_url` and copy whatever is returned in the HTTP response to the `local_dump_path`. 

Looking at the content of `dump.php.erb` the script creates a connection to the DB and `$dump->save('dump.mysql')` is invoked. `save` walks the DB and dumps its content to `dump.mysql` but nothing is echoed back.

Adding a `readfile` after `save` in `dump.php.erb` solves the issue.
